### PR TITLE
Adding new feature for auto-adding credit card brand based...

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,14 +57,6 @@
     <form>
         <div id="front">
             <div class="block">
-                <input id="visa" type="radio" name="card-type" />
-                <label for="visa">Visa</label>
-            </div>
-            <div class="block">
-                <input id="master" type="radio" name="card-type" />
-                <label for="master">MasterCard</label>
-            </div>
-            <div class="block">
                 <label for="number">Number</label>
                 <input id="number" type="text" maxlength="16" />
             </div>
@@ -82,7 +74,7 @@
         <div id="back">
             <div class="block">
                 <label for="cvv">CVV</label>
-                <input id="cvv" type="text" maxlegth="3" />
+                <input id="cvv" type="text" maxlength="3" />
             </div>
         </div>
         <div class="block">

--- a/js/script.js
+++ b/js/script.js
@@ -1,18 +1,10 @@
 $( document ).ready(function() {
     $("#back, #front").click(function () {
         if (this.id == "back") {
-            $(".flip-container").addClass("flip");    
+            $(".flip-container").addClass("flip");
         }
         else if (this.id == "front") {
-            $(".flip-container").removeClass("flip");    
-        }
-    });
-    $("#visa, #master").click(function () {
-        if (this.id == "visa") {
-            $("#card__image").attr("src", "assets/images/visa.png");
-        }
-        else if (this.id == "master") {
-            $("#card__image").attr("src", "assets/images/master.png");
+            $(".flip-container").removeClass("flip");
         }
     });
     $("#name, #number, #month, #cvv, #year").bind("change paste keyup", function() {
@@ -20,7 +12,27 @@ $( document ).ready(function() {
             $(".card__name").text($(this).val());
         }
         else if (this.id == "number") {
-            $(".card__number").text($(this).val());
+            var VISA_PREFIXES = ["4539", "4556", "4916", "4532", "4929", "4485", "4716"]; // Prefixes for VISA cards
+            var MC_PREFIXES = ["51", "52", "53", "54", "55"]; // Prefixes for Master Card cards
+            var field_value = $(this).val();
+
+            if (field_value.charAt(0) === "4" && field_value.length >= 4) {
+                var prefix = field_value.slice(0, 4);
+
+                if (VISA_PREFIXES.includes(prefix)) {
+                    $("#card__image").attr("src", "assets/images/visa.png");
+                }
+            } else if (field_value.charAt(0) === "5" && field_value.length >= 2) {
+                var prefix = field_value.slice(0, 2);
+
+                if (MC_PREFIXES.includes(prefix)) {
+                    $("#card__image").attr("src", "assets/images/master.png");
+                }
+            } else {
+                $("#card__image").attr("src", "");
+            }
+
+            $(".card__number").text(field_value);
         }
         else if (this.id == "month") {
             $(".card__month").text($(this).val());


### PR DESCRIPTION
Adding new feature for auto-adding credit card brand based on the card number.

While you input your string into the "Number" text box. The JS will compare it against two arrays (one for VISA and other for Master Card) containing the prefixes, if your string prefix matches one in the array, the logo will be automatically added.
- Deleted the input fields for manually choosing between VISA and Master Card.
- Fixed a typo in the HTML (maxlength in the CVV field)
- Added the logic for comparing the number of the credit card
